### PR TITLE
fix: add window-title to format string to populate WindowTitle field

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -86,7 +86,7 @@ func (c *AeroSpaceWM) GetAllWindows() ([]Window, error) {
 		[]string{
 			"--all",
 			"--json",
-			"--format", "%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+			"--format", "%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 		},
 	)
 	if err != nil {
@@ -127,7 +127,7 @@ func (c *AeroSpaceWM) GetAllWindowsByWorkspace(workspaceName string) ([]Window, 
 		[]string{
 			"--workspace", workspaceName,
 			"--json",
-			"--format", "%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+			"--format", "%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 		},
 	)
 	if err != nil {
@@ -169,7 +169,7 @@ func (c *AeroSpaceWM) GetFocusedWindow() (*Window, error) {
 		[]string{
 			"--focused",
 			"--json",
-			"--format", "%{window-id} %{app-name} %{app-bundle-id} %{workspace}",
+			"--format", "%{window-id} %{window-title} %{app-name} %{app-bundle-id} %{workspace}",
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes issue where window titles were always empty in GetAllWindows, GetAllWindowsByWorkspace, and GetFocusedWindow functions. The format string was missing the %{window-title} placeholder, causing the WindowTitle field to remain unpopulated.

Closes #19