### PR TITLE
feat(workspaces): adds move functionality to the ws service

### DIFF
--- a/pkg/aerospace/workspaces/workspaces.go
+++ b/pkg/aerospace/workspaces/workspaces.go
@@ -177,6 +177,11 @@ func (s *Service) MoveWindowToWorkspace(args MoveWindowToWorkspaceArgs) error {
 //	    WrapAround: true,
 //	})
 func (s *Service) MoveWindowToWorkspaceWithOpts(args MoveWindowToWorkspaceArgs, opts MoveWindowToWorkspaceOpts) error {
+	// Validate incompatible options
+	if opts.Stdin && opts.NoStdin {
+		return fmt.Errorf("cannot specify both --stdin and --no-stdin options")
+	}
+
 	cmdArgs := []string{args.WorkspaceName}
 
 	if opts.WindowID != nil {

--- a/pkg/aerospace/workspaces/workspaces.go
+++ b/pkg/aerospace/workspaces/workspaces.go
@@ -76,6 +76,9 @@ type WorkspacesService interface {
 	// MoveWindowToWorkspaceWithOpts moves a window to a specified workspace with options.
 	// opts must be provided and contains optional parameters.
 	MoveWindowToWorkspaceWithOpts(args MoveWindowToWorkspaceArgs, opts MoveWindowToWorkspaceOpts) error
+
+	// MoveBackAndForth switches between the focused workspace and previously focused workspace.
+	MoveBackAndForth() error
 }
 
 // NewService creates a new workspace service with the given AeroSpace client connection.
@@ -210,6 +213,34 @@ func (s *Service) MoveWindowToWorkspaceWithOpts(args MoveWindowToWorkspaceArgs, 
 
 	if response.ExitCode != 0 {
 		return fmt.Errorf("failed to move window to workspace: %s", response.StdErr)
+	}
+
+	return nil
+}
+
+// MoveBackAndForth switches between the focused workspace and previously focused workspace.
+//
+// It is equivalent to running the command:
+//
+//	aerospace workspace-back-and-forth
+//
+// Unlike focus-back-and-forth, workspace-back-and-forth always succeeds.
+// Because unlike windows, workspaces can not be "closed".
+// Workspaces are name-addressable objects that are created and destroyed on the fly.
+//
+// Returns an error if the operation fails.
+//
+// Usage:
+//
+//	err := workspaceService.MoveBackAndForth()
+func (s *Service) MoveBackAndForth() error {
+	response, err := s.client.SendCommand("workspace-back-and-forth", []string{})
+	if err != nil {
+		return err
+	}
+
+	if response.ExitCode != 0 {
+		return fmt.Errorf("failed to switch workspace back and forth: %s", response.StdErr)
 	}
 
 	return nil

--- a/pkg/aerospace/workspaces/workspaces.go
+++ b/pkg/aerospace/workspaces/workspaces.go
@@ -65,6 +65,32 @@ type MoveWindowToWorkspaceOpts struct {
 	NoStdin bool
 }
 
+// MoveWorkspaceToMonitorArgs contains arguments for MoveWorkspaceToMonitor.
+// Exactly one of Direction, Order, or Patterns must be specified.
+type MoveWorkspaceToMonitorArgs struct {
+	// Direction specifies the direction to move the workspace (left|down|up|right).
+	// Move workspace to monitor in direction relative to the focused monitor.
+	Direction string
+
+	// Order specifies the order-based movement (next|prev).
+	// Move the workspace to next or prev monitor relative to the monitor the workspace currently belongs to.
+	Order string
+
+	// Patterns specifies one or more monitor patterns to match.
+	// Finds the first matching monitor and moves the workspace there.
+	// Multiple monitor patterns are useful for different monitor configurations.
+	Patterns []string
+}
+
+// MoveWorkspaceToMonitorOpts contains optional parameters for MoveWorkspaceToMonitor.
+type MoveWorkspaceToMonitorOpts struct {
+	// Workspace specifies which workspace to move. If not set, the focused workspace is moved.
+	Workspace *string
+
+	// WrapAround allows moving workspace between first and last monitors.
+	WrapAround bool
+}
+
 // WorkspacesService defines the interface for workspace operations in AeroSpaceWM.
 type WorkspacesService interface {
 	// GetFocusedWorkspace returns the currently focused workspace.
@@ -79,6 +105,10 @@ type WorkspacesService interface {
 
 	// MoveBackAndForth switches between the focused workspace and previously focused workspace.
 	MoveBackAndForth() error
+
+	// MoveWorkspaceToMonitor moves a workspace to a monitor.
+	// Supports three modes: direction-based (left|down|up|right), order-based (next|prev), or pattern-based.
+	MoveWorkspaceToMonitor(args MoveWorkspaceToMonitorArgs, opts MoveWorkspaceToMonitorOpts) error
 }
 
 // NewService creates a new workspace service with the given AeroSpace client connection.

--- a/pkg/aerospace/workspaces/workspaces_test.go
+++ b/pkg/aerospace/workspaces/workspaces_test.go
@@ -278,6 +278,265 @@ func TestWorkspaceService(t *testing.T) {
 				}
 			})
 		})
+
+		t.Run("MoveWorkspaceToMonitor", func(tt *testing.T) {
+			tt.Run("direction mode - left", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"left"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Direction: "left",
+				}, MoveWorkspaceToMonitorOpts{})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			tt.Run("direction mode - all directions", func(ttt *testing.T) {
+				directions := []string{"left", "down", "up", "right"}
+				for _, dir := range directions {
+					ttt.Run(dir, func(tttt *testing.T) {
+						ctrl := gomock.NewController(tttt)
+						defer ctrl.Finish()
+
+						mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+						service := NewService(mockConn)
+
+						mockConn.EXPECT().
+							SendCommand(
+								"move-workspace-to-monitor",
+								[]string{dir},
+							).
+							Return(
+								&client.Response{
+									StdOut: "",
+								},
+								nil,
+							)
+
+						err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+							Direction: dir,
+						}, MoveWorkspaceToMonitorOpts{})
+						if err != nil {
+							tttt.Fatalf("unexpected error: %v", err)
+						}
+					})
+				}
+			})
+
+			tt.Run("order mode - next", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"next"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Order: "next",
+				}, MoveWorkspaceToMonitorOpts{})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			tt.Run("order mode - prev", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"prev"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Order: "prev",
+				}, MoveWorkspaceToMonitorOpts{})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			tt.Run("pattern mode - single pattern", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"HDMI-1"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Patterns: []string{"HDMI-1"},
+				}, MoveWorkspaceToMonitorOpts{})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			tt.Run("pattern mode - multiple patterns", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"HDMI-1", "DP-1"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Patterns: []string{"HDMI-1", "DP-1"},
+				}, MoveWorkspaceToMonitorOpts{})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			tt.Run("with workspace option", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				workspace := "my-workspace"
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"--workspace", "my-workspace", "left"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Direction: "left",
+				}, MoveWorkspaceToMonitorOpts{
+					Workspace: &workspace,
+				})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			tt.Run("with wrap-around option", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"--wrap-around", "next"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Order: "next",
+				}, MoveWorkspaceToMonitorOpts{
+					WrapAround: true,
+				})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			tt.Run("with all options", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				workspace := "my-workspace"
+				mockConn.EXPECT().
+					SendCommand(
+						"move-workspace-to-monitor",
+						[]string{"--workspace", "my-workspace", "--wrap-around", "right"},
+					).
+					Return(
+						&client.Response{
+							StdOut: "",
+						},
+						nil,
+					)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Direction: "right",
+				}, MoveWorkspaceToMonitorOpts{
+					Workspace:  &workspace,
+					WrapAround: true,
+				})
+				if err != nil {
+					ttt.Fatalf("unexpected error: %v", err)
+				}
+			})
+		})
 	})
 
 	t.Run("Error cases", func(tt *testing.T) {
@@ -426,6 +685,133 @@ func TestWorkspaceService(t *testing.T) {
 				Times(1)
 
 			err := service.MoveBackAndForth()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+
+		t.Run("MoveWorkspaceToMonitor validation errors", func(tt *testing.T) {
+			tt.Run("no mode specified", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{}, MoveWorkspaceToMonitorOpts{})
+				if err == nil {
+					ttt.Fatal("expected error for no mode specified, got nil")
+				}
+				if err.Error() != "must specify exactly one of: Direction, Order, or Patterns" {
+					ttt.Fatalf("expected specific error message, got: %v", err)
+				}
+			})
+
+			tt.Run("multiple modes specified", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Direction: "left",
+					Order:     "next",
+				}, MoveWorkspaceToMonitorOpts{})
+				if err == nil {
+					ttt.Fatal("expected error for multiple modes, got nil")
+				}
+				if err.Error() != "cannot specify multiple modes; must specify exactly one of: Direction, Order, or Patterns" {
+					ttt.Fatalf("expected specific error message, got: %v", err)
+				}
+			})
+
+			tt.Run("invalid direction", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Direction: "invalid",
+				}, MoveWorkspaceToMonitorOpts{})
+				if err == nil {
+					ttt.Fatal("expected error for invalid direction, got nil")
+				}
+				if err.Error() != "invalid direction \"invalid\", must be one of: left, down, up, right" {
+					ttt.Fatalf("expected specific error message, got: %v", err)
+				}
+			})
+
+			tt.Run("invalid order", func(ttt *testing.T) {
+				ctrl := gomock.NewController(ttt)
+				defer ctrl.Finish()
+
+				mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+				service := NewService(mockConn)
+
+				err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+					Order: "invalid",
+				}, MoveWorkspaceToMonitorOpts{})
+				if err == nil {
+					ttt.Fatal("expected error for invalid order, got nil")
+				}
+				if err.Error() != "invalid order \"invalid\", must be one of: next, prev" {
+					ttt.Fatalf("expected specific error message, got: %v", err)
+				}
+			})
+		})
+
+		t.Run("MoveWorkspaceToMonitor non-zero exit code", func(tt *testing.T) {
+			ctrl := gomock.NewController(tt)
+			defer ctrl.Finish()
+
+			mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+			service := NewService(mockConn)
+
+			mockConn.EXPECT().
+				SendCommand(
+					"move-workspace-to-monitor",
+					[]string{"left"},
+				).
+				Return(
+					&client.Response{
+						ExitCode: 1,
+						StdErr:   "workspace has monitor force assignment",
+					},
+					nil,
+				)
+
+			err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+				Direction: "left",
+			}, MoveWorkspaceToMonitorOpts{})
+			if err == nil {
+				t.Fatal("expected error for non-zero exit code, got nil")
+			}
+			if err.Error() != "failed to move workspace to monitor: workspace has monitor force assignment" {
+				t.Fatalf("expected specific error message, got: %v", err)
+			}
+		})
+
+		t.Run("MoveWorkspaceToMonitor connection error", func(tt *testing.T) {
+			ctrl := gomock.NewController(tt)
+			defer ctrl.Finish()
+
+			mockConn := mock_client.NewMockAeroSpaceConnection(ctrl)
+			service := NewService(mockConn)
+
+			mockConn.EXPECT().
+				SendCommand(
+					"move-workspace-to-monitor",
+					[]string{"left"},
+				).
+				Return(nil, fmt.Errorf("connection failed")).
+				Times(1)
+
+			err := service.MoveWorkspaceToMonitor(MoveWorkspaceToMonitorArgs{
+				Direction: "left",
+			}, MoveWorkspaceToMonitorOpts{})
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}


### PR DESCRIPTION
This PR adds workspace movement functionality between monitors and enhances validation for incompatible options. It introduces three new methods to the workspace service and comprehensive test coverage.

## Changes

### New Features
- **`MoveWorkspaceToMonitor` method**: Moves workspaces to monitors using three modes:
  - Direction-based: `left`, `down`, `up`, `right` (relative to focused monitor)
  - Order-based: `next`, `prev` (relative to current monitor)
  - Pattern-based: Match monitor patterns (e.g., `HDMI-1`, `DP-1`)
- **`MoveBackAndForth` method**: Switches between focused and previously focused workspaces
- **Enhanced validation**: Prevents specifying both `--stdin` and `--no-stdin` options in `MoveWindowToWorkspaceWithOpts`

### Implementation Details
- Added `MoveWorkspaceToMonitorArgs` struct with exclusive mode selection (exactly one of Direction, Order, or Patterns must be specified)
- Added `MoveWorkspaceToMonitorOpts` struct with workspace specification and wrap-around support
- Updated `WorkspacesService` interface to include new methods
- Added comprehensive input validation for all movement modes
- Focus follows the moved workspace (workspace stays focused after movement)

### Testing
- Added interface compliance test to ensure `Service` implements `WorkspacesService`
- Added extensive test coverage for all movement modes and options
- Added error handling tests for validation failures, connection errors, and non-zero exit codes
- Tested all direction combinations, order modes, and pattern matching scenarios


## Notes
- The `MoveWorkspaceToMonitor` method fails for workspaces with monitor force assignment (consistent with underlying AeroSpace behavior)
- `MoveBackAndForth` always succeeds since workspaces cannot be "closed" like windows
- All new methods include proper error handling and return meaningful error messages
